### PR TITLE
Use sample rate of the loaded track instead of the default

### DIFF
--- a/player.py
+++ b/player.py
@@ -61,7 +61,7 @@ def analyze(buffers):
 
 
 def load(filename, *, force=False):
-    y, sample_rate = librosa.load(filename, mono=False)
+    y, sample_rate = librosa.load(filename, mono=False, sr=None)
 
     path_inf = Path(filename + '.inf')
     if not force and path_inf.exists():
@@ -69,7 +69,7 @@ def load(filename, *, force=False):
             beat_frames, jumps = pickle.load(fh)
     else:
         print('Analyzing…')
-        y_mono, _ = librosa.load(filename)
+        y_mono, _ = librosa.load(filename, sr=sample_rate)
         tempo, beat_frames = librosa.beat.beat_track(y=y_mono, sr=sample_rate)
         buffers_mono = compute_buffers(y_mono, beat_frames)
         jumps = analyze(buffers_mono)


### PR DESCRIPTION
Hi! i've been looking for something like this for ages and want to help make it better.

I noticed the quality of tracks i have in FLAC format were getting particularly crusty when played through infinity-player so i dug around in librosa and noticed that leaving the `sr` argument off of `librosa.load` results in a sample rate of 22050 kbit/s. on the other hand, setting it to `None` makes the loader use the sample rate of the actual file.

My first instinct was to load one low-quality buffer for analysis and a high-quality one for playing, since i assumed analysis time would go up significantly with higher sample rates. however, since sample rates are not necessarily easily divisible that required a lot of extra math compared to just analyzing the higher sample rate.  i've played a variety of tracks of varying quality with this change and not noticed a significant change in the analysis time or the quality of the calculation.