### PR TITLE
Feature suggestion: Laplacian segmentation

### DIFF
--- a/player.py
+++ b/player.py
@@ -6,7 +6,6 @@ import pickle
 import random
 import shutil
 from pathlib import Path
-from multiprocessing import Pool
 
 import librosa
 import numpy

--- a/player.py
+++ b/player.py
@@ -21,19 +21,25 @@ with open(BASE_DIR / 'timbre.pickle', 'rb') as fh:
     TIMBRE_PATTERNS = pickle.load(fh)
 
 
-def print_progress(i, n):
-    cols, lines = shutil.get_terminal_size()
-    pos = i * (cols - 5) // n
-    s = ''
-    for x in range(cols - 5):
-        if x == pos:
-            s += '|'
-        elif x < pos:
-            s += '='
-        else:
-            s += '-'
-    s += f' {i:>4}'
-    print(s, end='\r')
+class Progress:
+    def __init__(self, n, segments):
+        self.n = n
+        self.indices = {}
+        for k, v in segments.items():
+            for beat in v:
+                self.indices[beat] = str(k)
+
+    def update(self, i):
+        cols, _ = shutil.get_terminal_size()
+        pos = lambda k: k * (cols - 7) // self.n
+        s = (['='] * pos(i)) + (['-'] * (pos(self.n) - pos(i)))
+        for x in range(self.n):
+            if x == i:
+                s[pos(x)] = '|'
+            elif x in self.indices:
+                s[pos(x)] = self.indices[x]
+
+        print(f'[{"".join(s)}] {i:>4}', end='\r')
 
 
 def compute_buffers(y, beat_samples):
@@ -183,7 +189,7 @@ def get_next_position(i, jumps, counts):
     return j[0] + 1
 
 
-def play(buffers, sample_rate, jumps):
+def play(buffers, sample_rate, jumps, progress):
     i = 0
     n = len(buffers)
     counts = numpy.zeros(n)
@@ -191,9 +197,9 @@ def play(buffers, sample_rate, jumps):
     with soundcard.default_speaker().player(samplerate=sample_rate) as sp:
         try:
             while True:
+                progress.update(i)
                 sp.play(buffers[i])
                 counts[i] += 1
-                print_progress(i, n)
 
                 i = get_next_position(i, jumps, counts)
                 if i >= n:
@@ -219,13 +225,14 @@ def main():
 
     print('Loading', args.filename)
     buffers, sample_rate, segments = load(args.filename, force=args.force)
+    progress = Progress(len(buffers), segments)
     jumps = jumps_from_segments(len(buffers), segments)
     jumps = enhance(jumps, args.threshold)
     jump_count = sum(sum(jumps > 0))
 
     print(f'Detected {jump_count} jump opportunities on {len(buffers)} beats')
     print('Playing… (Press Ctrl-C to stop)')
-    play(buffers, sample_rate, jumps)
+    play(buffers, sample_rate, jumps, progress)
 
 
 if __name__ == '__main__':

--- a/player.py
+++ b/player.py
@@ -10,6 +10,8 @@ from multiprocessing import Pool
 
 import librosa
 import numpy
+import scipy
+import sklearn
 import soundcard
 from PIL import Image
 
@@ -55,10 +57,85 @@ def timbre(y):
     return numpy.linalg.inv(t) @ s
 
 
-def analyze(buffers):
-    with Pool() as p:
-        timbres = numpy.array(p.map(timbre, buffers)).T
-    return librosa.segment.recurrence_matrix(timbres, width=4, mode='affinity')
+def get_track_segments(filename, sample_rate):
+    # https://librosa.org/librosa_gallery/auto_examples/plot_segmentation.html#sphx-glr-auto-examples-plot-segmentation-py
+    bins_per_octave = 12 * 3
+    n_octaves = 7
+
+    y_mono, _ = librosa.load(filename, sr=sample_rate)
+    _, beats = librosa.beat.beat_track(y=y_mono, sr=sample_rate, trim=False)
+    cqt = librosa.cqt(
+            y=y_mono,
+            sr=sample_rate,
+            bins_per_octave=bins_per_octave,
+            n_bins=n_octaves * bins_per_octave,
+        )
+    C = librosa.amplitude_to_db(numpy.abs(cqt), ref=numpy.max)
+    Csync = librosa.util.sync(C, beats, aggregate=numpy.median)
+
+    R = librosa.segment.recurrence_matrix(Csync, width=3, mode='affinity', sym=True)
+    df = librosa.segment.timelag_filter(scipy.ndimage.median_filter)
+    Rf = df(R, size=(1, 7))
+
+    mfcc = librosa.feature.mfcc(y=y_mono, sr=sample_rate)
+    Msync = librosa.util.sync(mfcc, beats)
+
+    path_distance = numpy.sum(numpy.diff(Msync, axis=1) ** 2, axis=0)
+    sigma = numpy.median(path_distance)
+    path_sim = numpy.exp(-path_distance / sigma)
+
+    R_path = numpy.diag(path_sim, k=1) + numpy.diag(path_sim, k=-1)
+
+    deg_path = numpy.sum(R_path, axis=1)
+    deg_rec = numpy.sum(Rf, axis=1)
+
+    mu = deg_path.dot(deg_path + deg_rec) / numpy.sum((deg_path + deg_rec) ** 2)
+
+    A = mu * Rf + (1 - mu) * R_path
+
+    L = scipy.sparse.csgraph.laplacian(A, normed=True)
+
+    _, evecs = scipy.linalg.eigh(L)
+
+    evecs = scipy.ndimage.median_filter(evecs, size=(9, 1))
+
+    Cnorm = numpy.cumsum(evecs**2, axis=1) ** 0.5
+
+    k = 5
+
+    X = evecs[:, :k] / Cnorm[:, k - 1 : k]
+
+    KM = sklearn.cluster.KMeans(n_clusters=k)
+
+    seg_ids = KM.fit_predict(X)
+
+    bound_beats = 1 + numpy.flatnonzero(seg_ids[:-1] != seg_ids[1:])
+    bound_beats = librosa.util.fix_frames(bound_beats, x_min=0)
+    bound_segs = list(seg_ids[bound_beats])
+
+    segments = {}
+    for label, beat in zip(bound_segs, bound_beats):
+        if label not in segments:
+            segments[label] = []
+        segments[label].append(beat.item())
+
+    discard = [label for label in segments if not segments[label]]
+    for label in discard:
+        del segments[label]
+
+    ordered = sorted(segments.values(), key=lambda sublist: sorted(sublist))
+    segments = dict(enumerate(ordered))
+
+    return beats, segments
+
+
+def jumps_from_segments(n, segments):
+    jumps = numpy.eye(n)
+
+    for frames in segments.values():
+        jumps[numpy.ix_(frames, frames)] = 1.0
+
+    return numpy.abs(jumps)
 
 
 def load(filename, *, force=False):
@@ -67,30 +144,24 @@ def load(filename, *, force=False):
     path_inf = Path(filename + '.inf')
     if not force and path_inf.exists():
         with gzip.open(path_inf, 'rb') as fh:
-            beat_samples, jumps = pickle.load(fh)
+            beat_frames, segments = pickle.load(fh)
     else:
         print('Analyzing…')
-        y_mono, _ = librosa.load(filename, sr=sample_rate)
-        tempo, beat_samples = librosa.beat.beat_track(
-            y=y_mono, sr=sample_rate, units='samples'
-        )
-        buffers_mono = compute_buffers(y_mono, beat_samples)
-        jumps = analyze(buffers_mono)
-
+        beat_frames, segments = get_track_segments(filename, sample_rate)
         with gzip.open(path_inf, 'wb') as fh:
-            pickle.dump((beat_samples, jumps), fh)
+            pickle.dump((beat_frames, segments), fh)
 
-    return compute_buffers(y, beat_samples), sample_rate, jumps
+    return compute_buffers(y, beat_frames), sample_rate, segments
 
 
 def enhance(jumps, threshold):
     n = len(jumps)
 
     # beats are more similar if the surrounding beats are similar
-    for _ in range(4):
-        jumps_before = numpy.roll(jumps, (-1, -1), (0, 1))
-        jumps_after = numpy.roll(jumps, (1, 1), (0, 1))
-        jumps = 0.4 * jumps_before + 0.4 * jumps_after + 0.2 * jumps
+    # for _ in range(4):
+    #    jumps_before = numpy.roll(jumps, (-1, -1), (0, 1))
+    #    jumps_after = numpy.roll(jumps, (1, 1), (0, 1))
+    #    jumps = 0.4 * jumps_before + 0.4 * jumps_after + 0.2 * jumps
 
     # scale
     x_max = jumps.max()
@@ -98,11 +169,9 @@ def enhance(jumps, threshold):
     y_max = x_max ** 0.5
     jumps = (jumps - x_min) / (x_max - x_min) * y_max
     jumps *= jumps > 0
-    jumps += numpy.eye(n)
 
     # privilege jumps back in order to prolong playing
     jumps[:] *= numpy.linspace(numpy.ones(n), numpy.ones(n) * 0.5, n)
-
     return jumps
 
 
@@ -149,7 +218,8 @@ def main():
     args = parse_args()
 
     print('Loading', args.filename)
-    buffers, sample_rate, jumps = load(args.filename, force=args.force)
+    buffers, sample_rate, segments = load(args.filename, force=args.force)
+    jumps = jumps_from_segments(len(buffers), segments)
     jumps = enhance(jumps, args.threshold)
     jump_count = sum(sum(jumps > 0))
 

--- a/player.py
+++ b/player.py
@@ -196,7 +196,7 @@ def play(buffers, sample_rate, jumps, progress):
     counts = numpy.zeros(n)
     jumped = True  # never jump at start of playback
 
-    with soundcard.default_speaker().player(samplerate=sample_rate) as sp:
+    with soundcard.default_speaker().player(samplerate=sample_rate, blocksize=8192) as sp:
         try:
             while True:
                 progress.update(i)

--- a/player.py
+++ b/player.py
@@ -20,23 +20,25 @@ with open(BASE_DIR / 'timbre.pickle', 'rb') as fh:
     TIMBRE_PATTERNS = pickle.load(fh)
 
 
+def colorize(k):
+    colors = [31,32,34,93,95,96]
+    return f"\033[{colors[k % len(colors)]}m{k}\033[0m"
+
 class Progress:
     def __init__(self, n, segments):
         self.n = n
         self.indices = {}
         for k, v in segments.items():
             for beat in v:
-                self.indices[beat] = str(k)
+                self.indices[beat] = colorize(k)
 
     def update(self, i):
         cols, _ = shutil.get_terminal_size()
         pos = lambda k: k * (cols - 7) // self.n
         s = (['='] * pos(i)) + (['-'] * (pos(self.n) - pos(i)))
-        for x in range(self.n):
-            if x == i:
-                s[pos(x)] = '|'
-            elif x in self.indices:
-                s[pos(x)] = self.indices[x]
+        s[pos(i)] = '|'
+        for x in self.indices:
+            s[pos(x)] = self.indices[x]
 
         print(f'[{"".join(s)}] {i:>4}', end='\r')
 

--- a/player.py
+++ b/player.py
@@ -193,6 +193,7 @@ def play(buffers, sample_rate, jumps, progress):
     i = 0
     n = len(buffers)
     counts = numpy.zeros(n)
+    jumped = True  # never jump at start of playback
 
     with soundcard.default_speaker().player(samplerate=sample_rate) as sp:
         try:
@@ -201,7 +202,13 @@ def play(buffers, sample_rate, jumps, progress):
                 sp.play(buffers[i])
                 counts[i] += 1
 
-                i = get_next_position(i, jumps, counts)
+                if jumped:  # never jump two beats in a row
+                    i += 1
+                    jumped = False
+                else:
+                    j = get_next_position(i, jumps, counts)
+                    jumped = j != (i + 1)
+                    i = j
                 if i >= n:
                     i = 0
         except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ librosa
 numpy
 Pillow
 soundcard
+scipy
+sklearn

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy
 Pillow
 soundcard
 scipy
-sklearn
+scikit-learn


### PR DESCRIPTION
This is not ready for merge, it's more informative.
In the librosa docs, there is an example of using [laplacian segmentation](https://librosa.org/librosa_gallery/auto_examples/plot_segmentation.html#sphx-glr-auto-examples-plot-segmentation-py) to categorize different parts of a track:

<img width="1200" height="400" alt="Image" src="https://github.com/user-attachments/assets/91771a23-82c5-41fc-b8c6-31a6ede6f4a0" />

apparently remixatron does something like this but i didn't check their source, just the linked example from their issue board.

I've basically taken the example code and applied it to infinity-player: the get_track_segments function returns a mapping from integer labels to "segment starts"; lists of beats where the laplacian figured out that a section of a particular type starts. the jumps_from_segments function then takes that mapping and creates a "fake" recurrence matrix, where every "segment start" beat has every other segment beat of that type set to 1, so that

```python

jumps_from_segments(5, {0: [1, 3], 1: [2,4]}) == [
    [1.,0.,0.,0.,0.],
    [0.,1.,0.,1.,0.],
    [0.,0.,1.,0.,1.],
    [0.,1.,0.,1.,0.],
    [0.,0.,1.,0.,1.],
]
```

(the 1 in the first row is because jumps is initialized to `eye()`)

for debugging purposes i refactored print_progress to keep track of where these segment starts are, so jump points are visible in the progress bar.

i've also added a one-beat "cooldown" for jumps because i had issues with the player jumping at beat 0.

i don't understand the maths behind the example at all, and there is an annoying off-by-one error that i can't figure out where the same buffer seems to get played an extra time, or not at all... or something. but i think there is something to this, so i thought i should at least bring it to your attention. it may be too sloppy to actually use as-is.
